### PR TITLE
Add .cc, .m, and .mm

### DIFF
--- a/LS_COLORS
+++ b/LS_COLORS
@@ -1,8 +1,8 @@
 #                                    LS_COLORS
 # Maintainer: Magnus Woldrich <m@japh.se>
 #        URL: https://github.com/trapd00r/LS_COLORS
-#    Version: 0.239
-#    Updated: 2013-02-04 14:14:25
+#    Version: 0.240
+#    Updated: 2013-02-04 14:17:34
 #
 #   This is a collection of extension:color mappings, suitable to use as your
 #   LS_COLORS environment variable. Most of them use the extended color map,
@@ -85,6 +85,8 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .lisp                 38;5;204;1
 .log                  38;5;190
 .lua                  38;5;34;1
+.m                    38;5;130;3
+.mm                   38;5;130;3
 .map                  38;5;58;3
 .markdown             38;5;184
 .md                   38;5;184


### PR DESCRIPTION
.cc is the same color class as .cpp
.m, .mm (Obj C, Obj C++) are assigned 130 (brown), because of Cocoa (common Obj C/C++ library on OS X)
