### PR TITLE
Eliminated dependency on 'grep -P'

### DIFF
--- a/buildsuite
+++ b/buildsuite
@@ -17,6 +17,10 @@
 #
 
 # Functions {{{1
+lscolors_buildsuite_print_extensions() {
+  sed -r -e '/^[ ]+#/d; /^[^\.\*]/d; /^$/d; s/^([\.\*][^ ]+).*/\1/' ../LS_COLORS
+}
+
 verbose() {
   if [[ "$verbose" = "1" ]]; then
     echo "$1" >&2
@@ -121,6 +125,7 @@ while read line; do
       touch ./DIRECTORY/"$line"
     fi
   fi
-done < <(sed -r -e '/^[ ]+#/d; /^[^\.\*]/d; /^$/d' ../LS_COLORS | grep -Po '^[\.\*]([A-z0-9]+)' )
+done < <( lscolors_buildsuite_print_extensions )
+
 
 # vim: ft=sh foldmethod=marker:

--- a/buildsuite
+++ b/buildsuite
@@ -118,7 +118,7 @@ chmod 0777 WORLDWRITEABLE
 # Supported extensions
 while read line; do
   if [[ ! -f test"$line" ]]; then
-    line="${line//\*/}"
+    line="${line//\*/.}"
     if [[ "${line:0:1}" == "." ]]; then
       touch ./DIRECTORY/test"$line"
     else


### PR DESCRIPTION
Per #39, `grep -P` has unpredictable behavior depending on the local implementation. Therefore, this pull request eliminates the dependency on grep via an additional `sed` expression.