### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,7 +42,7 @@ DEVELOPERS
 ==========
 
 There's a [library][1] I've written that lets you use various LS COLORS on
-arbitary files and directories. A simple implementation can be found [here][2].
+arbitrary files and directories. A simple implementation can be found [here][2].
 
 Using this, you can do
 


### PR DESCRIPTION
@trapd00r, I've corrected a typographical error in the documentation of the [LS_COLORS](https://github.com/trapd00r/LS_COLORS) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.