### PR TITLE
Added the 'lhs' filetype for Literate Haskell Source files.  Literate

### DIFF
--- a/LS_COLORS
+++ b/LS_COLORS
@@ -226,6 +226,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .hi                   38;5;110
 #   haskell
 .hs                   38;5;81
+.lhs                  38;5;81
 
 # binaries {{{2
 # compiled apps for interpreted languages


### PR DESCRIPTION
Haskell Source files now appear with the same attributes as plain
Haskell Source files.