### PR TITLE
Updated README – information on loading via Zplugin (Zsh)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,6 +32,14 @@ echo 'eval $(dircolors -b $HOME/.dircolors)' >> $HOME/.bashrc
 . $HOME/.bashrc
 ```
 
+There's a Zsh plugin manager `Zplugin` that nicely works with this repository – `dircolors`
+will be ran once on each update:
+
+```
+zplugin ice atclone"dircolors -b LS_COLORS > c.zsh" atpull'%atclone' pick"c.zsh"
+zplugin light trapd00r/LS_COLORS
+```
+
 ZSH SYNTAX HIGHLIGHTING
 =======================
 


### PR DESCRIPTION
Hello,
I'm the author of Zplugin for Zsh. It is uber-elastic and this is nicely visible when approaching your LS_COLORS repository. `dircolors` is run only at clone, and then at each pull (update). This saves some CPU cycles.

I've updated README.md with Zplugin info. Could you merge? I already include that information on Zplugin README.md, but your repository has more likes and it would spread this interesting information, also to bash users, which may be encouraged to code a plugin manager.