### PR TITLE
jupyter lab/notebook ipynb extension added next to py

### DIFF
--- a/LS_COLORS
+++ b/LS_COLORS
@@ -174,6 +174,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .ahk                  38;5;41
 # python
 .py                   38;5;41
+.ipynb                38;5;41
 # ruby
 .rb                   38;5;41
 # perl


### PR DESCRIPTION
Hi,

I've added a python color for [project jupyter](https://jupyter.org/)'s notebooks which are quite popular in data science/academia.

Cheers,
Max