### PR TITLE
README: big clean-up and adding fish shell instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,7 @@
-LS_COLORS
-=========
+# LS_COLORS
 
 This is a collection of extension:color mappings, suitable to use as your
-LS COLORS environment variable. Most of them use the extended color map,
+`LS COLORS` environment variable. Most of them use the extended color map,
 described in the ECMA-48 document; in other words, you'll need a terminal
 with capabilities of displaying 256 colors.
 
@@ -42,18 +41,16 @@ eval ( dircolors --c-shell $HOME/LS_COLORS )
 
 Place it in `~/.config/fish/config.fish` or any `*.fish*` file inside `~/.config/fish/conf.d/` to be loaded.
 
-### Archlinux
+## Archlinux
 Archlinux users can install the [`lscolors-git`][3] package from the AUR for easy
 integration with bash, csh, or zsh.
 
-ZSH SYNTAX HIGHLIGHTING
-=======================
+## ZSH Syntax highlighting
 
 [zsh-syntax-highlighting-filetypes][0] highlights file on the command-line in
 realtime, using these colors.
 
-DEVELOPERS
-==========
+# Information for Developers
 
 There's a [library][1] I've written that lets you use various LS COLORS on
 arbitrary files and directories. A simple implementation can be found [here][2].
@@ -66,8 +63,7 @@ Using this, you can do
 
 ... and so on.
 
-SO WHAT DOES IT LOOK LIKE
-=========================
+# How does it look like
 
 Here's a screenshot:
 
@@ -83,8 +79,8 @@ And another one:
   [2]: https://github.com/trapd00r/File-LsColor/tree/master/bin
   [3]: https://aur.archlinux.org/packages/lscolors-git
 
-LEGAL
-=====
+# Legal 
+
 © Copyright 2014-2018 Magnus Woldrich.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY

--- a/README.markdown
+++ b/README.markdown
@@ -22,8 +22,9 @@ possible extensions, like htm and html, should have the same color.
 # Installation
 To install and use this file, put something like this is your shell resource
 file:
-
-    eval $( dircolors -b $HOME/LS_COLORS )
+```
+eval $( dircolors -b $HOME/LS_COLORS )
+```
 
 A quick way to install would be the following set of commands (assuming bash):
 
@@ -32,6 +33,14 @@ wget https://raw.github.com/trapd00r/LS_COLORS/master/LS_COLORS -O $HOME/.dircol
 echo 'eval $(dircolors -b $HOME/.dircolors)' >> $HOME/.bashrc
 . $HOME/.bashrc
 ```
+
+## For fish shell
+
+```
+eval ( dircolors --c-shell $HOME/LS_COLORS )
+```
+
+Place it in `~/.config/fish/config.fish` or any `*.fish*` file inside `~/.config/fish/conf.d/` to be loaded.
 
 ### Archlinux
 Archlinux users can install the [`lscolors-git`][3] package from the AUR for easy

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,14 @@
-# LS_COLORS
+### Table of contents
+* [LS_COLORS](#ls_colors)
+* [How does it look like](#how-does-it-look-like)
+* [Installation](#installation)
+  * [Arch Linux](#arch-linux)
+  * [ZSH syntax highlighting](#zsh-syntax-highlighting)
+  * [fish shell](#fish-shell)
+* [Information for Developers](#information-for-developers)
+* [Legal](#legal)
 
+# LS_COLORS
 This is a collection of extension:color mappings, suitable to use as your
 `LS COLORS` environment variable. Most of them use the extended color map,
 described in the ECMA-48 document; in other words, you'll need a terminal
@@ -18,6 +27,20 @@ For files that usually ends up next to each other, like html, css and js,
 try to pick colors that fits in nicely together. Filetypes with multiple
 possible extensions, like htm and html, should have the same color.
 
+# How does it look like
+Here's a screenshot _(font and minor color shades, of course, depend on terminal and its configuration)_:
+
+![Screenshot1](http://orig07.deviantart.net/f59a/f/2016/087/a/e/ls_colors_1_by_trapd00r-d9wrdoa.png)
+
+And another one:
+
+![Screenshot2](http://orig02.deviantart.net/5c73/f/2016/087/4/8/ls_colors_2_by_trapd00r-d9wrdrq.png)
+
+  [0]: https://github.com/trapd00r/zsh-syntax-highlighting-filetypes
+  [1]: https://github.com/trapd00r/File-LsColor
+  [2]: https://github.com/trapd00r/File-LsColor/tree/master/bin
+  [3]: https://aur.archlinux.org/packages/lscolors-git
+
 # Installation
 To install and use this file, put something like this is your shell resource
 file:
@@ -27,60 +50,41 @@ eval $( dircolors -b $HOME/LS_COLORS )
 
 A quick way to install would be the following set of commands (assuming bash):
 
-```sh
+```
 wget https://raw.github.com/trapd00r/LS_COLORS/master/LS_COLORS -O $HOME/.dircolors
 echo 'eval $(dircolors -b $HOME/.dircolors)' >> $HOME/.bashrc
 . $HOME/.bashrc
 ```
 
-## For fish shell
+## Arch Linux
+Arch Linux users can install the [`lscolors-git`][3] package from the AUR for easy
+integration with bash, csh, or zsh.
 
+## ZSH syntax highlighting
+[zsh-syntax-highlighting-filetypes][0] highlights file on the command-line in
+realtime, using these colors.
+
+## fish shell
 ```
 eval ( dircolors --c-shell $HOME/LS_COLORS )
 ```
 
 Place it in `~/.config/fish/config.fish` or any `*.fish*` file inside `~/.config/fish/conf.d/` to be loaded.
 
-## Archlinux
-Archlinux users can install the [`lscolors-git`][3] package from the AUR for easy
-integration with bash, csh, or zsh.
-
-## ZSH Syntax highlighting
-
-[zsh-syntax-highlighting-filetypes][0] highlights file on the command-line in
-realtime, using these colors.
-
 # Information for Developers
-
 There's a [library][1] I've written that lets you use various LS COLORS on
 arbitrary files and directories. A simple implementation can be found [here][2].
 
 Using this, you can do
+```
+find $HOME -maxdepth 1  | ls_color
 
-    find $HOME -maxdepth 1  | ls_color
-
-    mpc search artist Laleh | ls_color
+mpc search artist Laleh | ls_color
+```
 
 ... and so on.
 
-# How does it look like
-
-Here's a screenshot:
-
-![LS_COLORS](http://orig07.deviantart.net/f59a/f/2016/087/a/e/ls_colors_1_by_trapd00r-d9wrdoa.png)
-
-And another one:
-
-![LS_COLORS_2](http://orig02.deviantart.net/5c73/f/2016/087/4/8/ls_colors_2_by_trapd00r-d9wrdrq.png)
-
-
-  [0]: https://github.com/trapd00r/zsh-syntax-highlighting-filetypes
-  [1]: https://github.com/trapd00r/File-LsColor
-  [2]: https://github.com/trapd00r/File-LsColor/tree/master/bin
-  [3]: https://aur.archlinux.org/packages/lscolors-git
-
 # Legal 
-
 © Copyright 2014-2018 Magnus Woldrich.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY

--- a/README.markdown
+++ b/README.markdown
@@ -44,13 +44,13 @@ And another one:
 # Installation
 To install and use this file, put something like this is your shell resource
 file:
-```
+```shell
 eval $( dircolors -b $HOME/LS_COLORS )
 ```
 
 A quick way to install would be the following set of commands (assuming bash):
 
-```
+```shell
 wget https://raw.github.com/trapd00r/LS_COLORS/master/LS_COLORS -O $HOME/.dircolors
 echo 'eval $(dircolors -b $HOME/.dircolors)' >> $HOME/.bashrc
 . $HOME/.bashrc
@@ -65,7 +65,7 @@ integration with bash, csh, or zsh.
 realtime, using these colors.
 
 ## fish shell
-```
+```fish
 eval ( dircolors --c-shell $HOME/LS_COLORS )
 ```
 
@@ -76,7 +76,7 @@ There's a [library][1] I've written that lets you use various LS COLORS on
 arbitrary files and directories. A simple implementation can be found [here][2].
 
 Using this, you can do
-```
+```shell
 find $HOME -maxdepth 1  | ls_color
 
 mpc search artist Laleh | ls_color

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 ### Table of contents
 * [LS_COLORS](#ls_colors)
-* [How does it look like](#how-does-it-look-like)
+* [What does it look like?](#what-does-it-look-like)
 * [Installation](#installation)
   * [Arch Linux](#arch-linux)
   * [ZSH syntax highlighting](#zsh-syntax-highlighting)
@@ -10,7 +10,7 @@
 
 # LS_COLORS
 This is a collection of extension:color mappings, suitable to use as your
-`LS COLORS` environment variable. Most of them use the extended color map,
+`LS_COLORS` environment variable. Most of them use the extended color map,
 described in the ECMA-48 document; in other words, you'll need a terminal
 with capabilities of displaying 256 colors.
 
@@ -27,7 +27,7 @@ For files that usually ends up next to each other, like html, css and js,
 try to pick colors that fits in nicely together. Filetypes with multiple
 possible extensions, like htm and html, should have the same color.
 
-# How does it look like
+# What does it look like?
 Here's a screenshot _(font and minor color shades, of course, depend on terminal and its configuration)_:
 
 ![Screenshot1](http://orig07.deviantart.net/f59a/f/2016/087/a/e/ls_colors_1_by_trapd00r-d9wrdoa.png)


### PR DESCRIPTION
- [x] Archlinux -> Arch Linux
- [x] Unified the form of headings (no longer in different cases and different forms)
- [x] Unified form of code blocks
- [x] Removed a code block syntax highlighting from one block. GitHub shell code blocks syntax highlighting is messy and inconsistent. Removing highlighting from that code block also creates a unified look for all code blocks. 
- [x] Note on the screenshots that terminal output depends on font and terminal. In my terminal setup it looks pretty. In-repo screenshots have too pixelated `system`-like font, which is not best show-case. 'cmon, just look at `.sig` and `.signature` italics.
- [x] For screenshots, HTML replacement text changed. From not understandable 'LS_COLORS' to Screenshot'. 
- [x] Added 'Table of contents'
- [x] Instructions for `fish` shell users. `fish` is non-POSIX compliant shell, so needs special instructions.