### PR TITLE
Nix and dhall

### DIFF
--- a/LS_COLORS
+++ b/LS_COLORS
@@ -326,6 +326,8 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 *Makefile             38;5;155
 *MANIFEST             38;5;243
 *pm_to_blib           38;5;240
+# Functional Configuration
+.nix                  38;5;155
 # ruby rake
 .rake                 38;5;155
 # automake

--- a/LS_COLORS
+++ b/LS_COLORS
@@ -328,6 +328,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 *pm_to_blib           38;5;240
 # Functional Configuration
 .nix                  38;5;155
+.dhall                38;5;178
 # ruby rake
 .rake                 38;5;155
 # automake


### PR DESCRIPTION
Added colors for `.nix` files (used by NixOS/nix) and `.dhall` files. `.nix` files are used to build derivations in the nix system and hence are colored in the same way as `Makefile`. `.dhall` files are used as a substitute for `.yaml` files and take on the same coloring.