### PR TITLE
Fix install script quotes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -44,10 +44,10 @@ $ ( cd /tmp/LS_COLORS && sh install.sh )
 To enable the colors, add the following line to your shell's start-up script:
 
 For Bourne shell (e.g. ~/.bashrc or ~/.zshrc):
-  . ~/.local/share/lscolors.sh"
+  . "~/.local/share/lscolors.sh"
 
 For C shell (e.g. ~/.cshrc):
-  . ~/.local/share/lscolors.csh"
+  . "~/.local/share/lscolors.csh"
 $
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -9,10 +9,10 @@ if dircolors -b LS_COLORS > lscolors.sh && dircolors -c LS_COLORS > lscolors.csh
 To enable the colors, add the following line to your shell's start-up script:
 
 For Bourne shell (e.g. ~/.bashrc or ~/.zshrc):
-  . $lscolors_data_dir/lscolors.sh"
+  . "$lscolors_data_dir/lscolors.sh"
 
 For C shell (e.g. ~/.cshrc):
-  . $lscolors_data_dir/lscolors.csh
+  . "$lscolors_data_dir/lscolors.csh"
 
 EOF
   fi


### PR DESCRIPTION
The quotes in the install script and corresponding `README` section didn't match and weren't paired.