### PR TITLE
Add support for Asciidoc format

### DIFF
--- a/LS_COLORS
+++ b/LS_COLORS
@@ -73,7 +73,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .log                  38;5;190
 # plain-text {{{2
 .txt                  38;5;253
-# markup {{{2{{{}}}
+# markup {{{2
 .adoc                 38;5;184
 .asciidoc             38;5;184
 .etx                  38;5;184

--- a/LS_COLORS
+++ b/LS_COLORS
@@ -73,7 +73,9 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .log                  38;5;190
 # plain-text {{{2
 .txt                  38;5;253
-# markup {{{2
+# markup {{{2{{{}}}
+.adoc                 38;5;184
+.asciidoc             38;5;184
 .etx                  38;5;184
 .info                 38;5;184
 .markdown             38;5;184


### PR DESCRIPTION
Adds support for Asciidoc / Asciidoctor file extensions

Asciidoc is a markup format similar to Markdown, with more features.

- adds *.adoc and *.asciidoc according to https://asciidoctor.org/docs/asciidoc-recommended-practices/#document-extension
- *.asc wasn't added as it created a duplication with another format
- used the same colour scheme as other document formats, namely markdown