### PR TITLE
Add crx for Chrome and xpi for Firefox extensions

### DIFF
--- a/LS_COLORS
+++ b/LS_COLORS
@@ -553,6 +553,8 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .vpk                  38;5;215
 .bsp                  38;5;215
 .dmg                  38;5;215
+.crx                  38;5;215 # Google Chrome extension
+.xpi                  38;5;215 # Mozilla Firefox extension
   # }}}
   # segments from 0 to three digits after first extension letter {{{2
 .r[0-9]{0,2}          38;5;239


### PR DESCRIPTION
CRX and XPI files are packaged Chrome/Firefox browser extensions with
a ZIP archived source tree.

References:
.crx: https://developer.chrome.com/docs/extensions/mv3/linux_hosting/
.xpi: https://wiki.mozilla.org/Add-ons/Extension_Signing