### PR TITLE
Check for both `dircolors` & `gdircolors`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,16 @@
 
 lscolors_data_dir="${XDG_DATA_HOME:-$HOME/.local/share}"
 
-if dircolors -b LS_COLORS > lscolors.sh && dircolors -c LS_COLORS > lscolors.csh ; then
+if command -v dircolors > /dev/null; then
+  dircolors=dircolors
+elif command -v gdircolors > /dev/null; then
+  dircolors=gdircolors
+else
+  echo 'LS_COLORS/install.sh: (g)dircolors not found. Please install GNU coreutils.'
+  exit 69  # EX_UNAVAILABLE; see sysexits(3)
+fi
+
+if $dircolors -b LS_COLORS > lscolors.sh && $dircolors -c LS_COLORS > lscolors.csh ; then
   if mv -t "$lscolors_data_dir" lscolors.sh lscolors.csh ; then
     cat <<EOF
 To enable the colors, add the following line to your shell's start-up script:


### PR DESCRIPTION
If GNU coreutils was installed on macOS through Homebrew, then `dircolors` is instead called `gdircolors`.