### PR TITLE
LS_COLORS restructuring

### DIFF
--- a/LS_COLORS
+++ b/LS_COLORS
@@ -30,720 +30,600 @@
 # You should have received a copy of the Perl Artistic License along
 # with this program.  If not, see <http://www.perlfoundation.org/artistic_license_1_0>.
 
-# core
-BLK                   38;5;68
-CAPABILITY            38;5;17
-CHR                   38;5;113;1
-DIR                   38;5;30
-DOOR                  38;5;127
-EXEC                  38;5;208;1
-FIFO                  38;5;126
-FILE                  0
-LINK                  target
-MULTIHARDLINK         38;5;222;1
 # "NORMAL don't reset the bold attribute -
 # https://github.com/trapd00r/LS_COLORS/issues/11
 #NORMAL               38;5;254
-NORMAL                0
-ORPHAN                48;5;196;38;5;232;1
-OTHER_WRITABLE        38;5;220;1
-SETGID                48;5;3;38;5;0
-SETUID                38;5;220;1;3;100;1
-SOCK                  38;5;197
-STICKY                38;5;86;48;5;234
-STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
-*LS_COLORS 48;5;89;38;5;197;1;3;4;7 # :-)
-# documents
-*README               38;5;220;1
-*README.rst           38;5;220;1
-*README.md            38;5;220;1
-*LICENSE              38;5;220;1
-*COPYING              38;5;220;1
-*INSTALL              38;5;220;1
-*COPYRIGHT            38;5;220;1
-*AUTHORS              38;5;220;1
-*HISTORY              38;5;220;1
-*CONTRIBUTORS         38;5;220;1
-*PATENTS              38;5;220;1
-*VERSION              38;5;220;1
-*NOTICE               38;5;220;1
-*CHANGES              38;5;220;1
-.log                  38;5;190
-# plain-text
-.txt                  38;5;253
-# markup
-.adoc                 38;5;184
-.asciidoc             38;5;184
-.etx                  38;5;184
-.info                 38;5;184
-.markdown             38;5;184
-.md                   38;5;184
-.mkd                  38;5;184
-.nfo                  38;5;184
-.org                  38;5;184
-.pod                  38;5;184
-.rst                  38;5;184
-.tex                  38;5;184
-.textile              38;5;184
-# key-value, non-relational data
-.bib                  38;5;178
-.json                 38;5;178
-.jsonl                38;5;178
-.jsonnet              38;5;178
-.libsonnet            38;5;142
-.ndjson               38;5;178
-.msg                  38;5;178
-.pgn                  38;5;178
-.rss                  38;5;178
-.xml                  38;5;178
-.fxml                 38;5;178
-.toml                 38;5;178
-.yaml                 38;5;178
-.yml                  38;5;178
-.RData                38;5;178
-.rdata                38;5;178
-.xsd                  38;5;178
-.dtd                  38;5;178
-.sgml                 38;5;178
-.rng                  38;5;178
-.rnc                  38;5;178
-# binary
-.cbr                  38;5;141
-.cbz                  38;5;141
-.chm                  38;5;141
-.djvu                 38;5;141
-.pdf                  38;5;141
-.PDF                  38;5;141
-.mobi                 38;5;141
-.epub                 38;5;141
-# Microsoft
-# words
-.docm                 38;5;111;4
-.doc                  38;5;111
-.docx                 38;5;111
-.odb                  38;5;111
-.odt                  38;5;111
-.rtf                  38;5;111
-# presentation
-.odp                  38;5;166
-.pps                  38;5;166
-.ppt                  38;5;166
-.pptx                 38;5;166
-# Powerpoint show
-.ppts                 38;5;166
-# Powerpoint with enabled macros
-.pptxm                38;5;166;4
-# Powerpoint show with enabled macros
-.pptsm                38;5;166;4
-# spreadsheet
-.csv                  38;5;78
-.tsv                  38;5;78
-# Open document spreadsheet
-.ods                  38;5;112
-.xla                  38;5;76
-# Excel spreadsheet
-.xls                  38;5;112
-.xlsx                 38;5;112
-# Excel spreadsheet with macros
-.xlsxm                38;5;112;4
-# Excel module
-.xltm                 38;5;73;4
-.xltx                 38;5;73
-# macOS office suite
-.pages                38;5;111
-.numbers              38;5;112
-.key                  38;5;166
-# configs
-*config               1
-*cfg                  1
-*conf                 1
-*rc                   1
-*authorized_keys      1
-*known_hosts          1
-.ini                  1
-.plist                1
-# bash environment config
-.profile              1
-.bash_profile         1
-.bash_login           1
-.bash_logout          1
-# zsh environment config
-.zshenv               1
-.zprofile             1
-.zlogin               1
-.zlogout              1
-# vim
-.viminfo              1
-# cisco VPN client configuration
-.pcf                  1
-# adobe photoshop proof settings file
-.psf                  1
-# Sublime Text config
-.hidden-color-scheme  1
-.hidden-tmTheme       1
-.last-run             1
-.merged-ca-bundle     1
-.sublime-build        1
-.sublime-commands     1
-.sublime-keymap       1
-.sublime-settings     1
-.sublime-snippet      1
-.sublime-project      1
-.sublime-workspace    1
-.tmTheme              1
-.user-ca-bundle       1
-# RStudio config
-.rstheme              1
-# eclipse
-.epf                  1
-# code
-# version control
-.git                  38;5;197
-.gitignore            38;5;240
-.gitattributes        38;5;240
-.gitmodules           38;5;240
-# shell
-.awk                  38;5;172
-.bash                 38;5;172
-.bat                  38;5;172
-.BAT                  38;5;172
-.sed                  38;5;172
-.sh                   38;5;172
-.zsh                  38;5;172
-.vim                  38;5;172
-.kak                  38;5;172
-# interpreted
-.ahk                  38;5;41
-# python
-.py                   38;5;41
-.ipynb                38;5;41
-.xsh                  38;5;41
-# ruby
-.rb                   38;5;41
-.gemspec              38;5;41
-# perl
-.pl                   38;5;208
-.PL                   38;5;160
-.t                    38;5;114
-# sql
-.msql                 38;5;222
-.mysql                38;5;222
-.pgsql                38;5;222
-.sql                  38;5;222
-# Tool Command Language
-.tcl                  38;5;64;1
-# R language
-.r                    38;5;49
-.R                    38;5;49
-# GrADS script
-.gs                   38;5;81
-# Clojure
-.clj                  38;5;41
-.cljs                 38;5;41
-.cljc                 38;5;41
-# Clojure gorilla REPL worksheet
-.cljw                 38;5;41
-# Scala
-.scala                38;5;41
-.sc                   38;5;41
-# Dart
-.dart                 38;5;51
-# compiled
-# assembly language
-.asm                  38;5;81
-# LISP
-.cl                   38;5;81
-.lisp                 38;5;81
-.rkt                  38;5;81
-# Emacs Lisp
-.el                   38;5;81
-.elc                  38;5;241
-.eln                  38;5;241
-# lua
-.lua                  38;5;81
-# Moonscript
-.moon                 38;5;81
-# C
-.c                    38;5;81
-.C                    38;5;81
-.h                    38;5;110
-.H                    38;5;110
-.tcc                  38;5;110
-# C++
-.c++                  38;5;81
-.h++                  38;5;110
-.hpp                  38;5;110
-.hxx                  38;5;110
-.ii                   38;5;110
-# method file for Objective C
-.M                    38;5;110
-.m                    38;5;110
-# Csharp
-.cc                   38;5;81
-.cs                   38;5;81
-.cp                   38;5;81
-.cpp                  38;5;81
-.cxx                  38;5;81
-# Crystal
-.cr                   38;5;81
-# Google golang
-.go                   38;5;81
-# fortran
-.f                    38;5;81
-.F                    38;5;81
-.for                  38;5;81
-.ftn                  38;5;81
-.f90                  38;5;81
-.F90                  38;5;81
-.f95                  38;5;81
-.F95                  38;5;81
-.f03                  38;5;81
-.F03                  38;5;81
-.f08                  38;5;81
-.F08                  38;5;81
-# Nim
-.nim                  38;5;81
-.nimble               38;5;81
-# pascal
-.s                    38;5;110
-.S                    38;5;110
-# Rust
-.rs                   38;5;81
-# AppleScript
-.scpt                 38;5;219
-# Swift
-.swift                38;5;219
-# SimplexNumerica
-.sx                   38;5;81
-# Vala
-.vala                 38;5;81
-.vapi                 38;5;81
-# interface file in GHC - https://github.com/trapd00r/LS_COLORS/pull/9
-.hi                   38;5;110
-# haskell
-.hs                   38;5;81
-.lhs                  38;5;81
-# agda
-.agda                 38;5;81
-.lagda                38;5;81
-.lagda.tex            38;5;81
-.lagda.rst            38;5;81
-.lagda.md             38;5;81
-.agdai                38;5;110
-# Zig
-.zig                  38;5;81
-# V
-.v                    38;5;81
-# Python
-.pyc                  38;5;240
-# orchestration
-.tf                   38;5;168
-.tfstate              38;5;168
-.tfvars               38;5;168
-# html
-.css                  38;5;125;1
-.less                 38;5;125;1
-.sass                 38;5;125;1
-.scss                 38;5;125;1
-.htm                  38;5;125;1
-.html                 38;5;125;1
-.jhtm                 38;5;125;1
-.mht                  38;5;125;1
-.eml                  38;5;125;1
-.mustache             38;5;125;1
-# java
-.coffee               38;5;074;1
-.java                 38;5;074;1
-.js                   38;5;074;1
-.mjs                  38;5;074;1
-.jsm                  38;5;074;1
-.jsp                  38;5;074;1
-# php
-.php                  38;5;81
-# CakePHP view scripts and helpers
-.ctp                  38;5;81
-# Twig template engine
-.twig                 38;5;81
-# vb/a
-.vb                   38;5;81
-.vba                  38;5;81
-.vbs                  38;5;81
-# Build stuff
-*Dockerfile           38;5;155
-.dockerignore         38;5;240
-*Makefile             38;5;155
-*MANIFEST             38;5;243
-*pm_to_blib           38;5;240
-# Functional Configuration
-.nix                  38;5;155
-.dhall                38;5;178
-# ruby rake
-.rake                 38;5;155
-# automake
-.am                   38;5;242
-.in                   38;5;242
-.hin                  38;5;242
-.scan                 38;5;242
-.m4                   38;5;242
-.old                  38;5;242
-.out                  38;5;242
-.SKIP                 38;5;244
-# patch files
-.diff                 48;5;197;38;5;232
-.patch                48;5;197;38;5;232;1
-# graphics
-.bmp                  38;5;97
-.dicom                38;5;97
-.tiff                 38;5;97
-.tif                  38;5;97
-.TIFF                 38;5;97
-.cdr                  38;5;97
-.flif                 38;5;97
-.gif                  38;5;97
-.icns                 38;5;97
-.ico                  38;5;97
-.jpeg                 38;5;97
-.JPG                  38;5;97
-.jpg                  38;5;97
-.nth                  38;5;97
-.png                  38;5;97
-.psd                  38;5;97
-.pxd                  38;5;97
-.pxm                  38;5;97
-.xpm                  38;5;97
-.webp                 38;5;97
-# vector
-.ai                   38;5;99
-.eps                  38;5;99
-.epsf                 38;5;99
-.drw                  38;5;99
-.ps                   38;5;99
-.svg                  38;5;99
-# video
-.avi                  38;5;114
-.divx                 38;5;114
-.IFO                  38;5;114
-.m2v                  38;5;114
-.m4v                  38;5;114
-.mkv                  38;5;114
-.MOV                  38;5;114
-.mov                  38;5;114
-.mp4                  38;5;114
-.mpeg                 38;5;114
-.mpg                  38;5;114
-.ogm                  38;5;114
-.rmvb                 38;5;114
-.sample               38;5;114
-.wmv                  38;5;114
-# mobile/streaming
-.3g2                  38;5;115
-.3gp                  38;5;115
-.gp3                  38;5;115
-.webm                 38;5;115
-.gp4                  38;5;115
-.asf                  38;5;115
-.flv                  38;5;115
-.ts                   38;5;115
-.ogv                  38;5;115
-.f4v                  38;5;115
-# lossless
-.VOB                  38;5;115;1
-.vob                  38;5;115;1
-# subtitles
-.ass                  38;5;117
-.srt                  38;5;117
-.ssa                  38;5;117
-.sub                  38;5;117
-.sup                  38;5;117 # bitmap image track
-.vtt                  38;5;117
-# audio
-.3ga                  38;5;137;1
-.S3M                  38;5;137;1
-.aac                  38;5;137;1
-.amr                  38;5;137;1
-.au                   38;5;137;1
-.caf                  38;5;137;1
-.dat                  38;5;137;1
-.dts                  38;5;137;1
-.fcm                  38;5;137;1
-.m4a                  38;5;137;1
-.mod                  38;5;137;1
-.mp3                  38;5;137;1
-.mp4a                 38;5;137;1
-.oga                  38;5;137;1
-.ogg                  38;5;137;1
-.opus                 38;5;137;1
-.s3m                  38;5;137;1
-.sid                  38;5;137;1
-.wma                  38;5;137;1
-# lossless
-.ape                  38;5;136;1
-.aiff                 38;5;136;1
-.cda                  38;5;136;1
-.flac                 38;5;136;1
-.alac                 38;5;136;1
-.mid                  38;5;136;1
-.midi                 38;5;136;1
-.pcm                  38;5;136;1
-.wav                  38;5;136;1
-.wv                   38;5;136;1
-.wvc                  38;5;136;1
-# fonts
-.afm                  38;5;66
-.fon                  38;5;66
-.fnt                  38;5;66
-.pfb                  38;5;66
-.pfm                  38;5;66
-.ttf                  38;5;66
-.otf                  38;5;66
-# Web Open Font Format
-.woff                 38;5;66
-.woff2                38;5;66
-# postscript fonts
-.PFA                  38;5;66
-.pfa                  38;5;66
-# archives
-*.7z                   38;5;40
-*.a                    38;5;40
-*.arj                  38;5;40
-*.bz2                  38;5;40
-*.cpio                 38;5;40
-*.gz                   38;5;40
-*.lrz                  38;5;40
-*.lz                   38;5;40
-*.lzma                 38;5;40
-*.lzo                  38;5;40
-*.rar                  38;5;40
-*.s7z                  38;5;40
-*.sz                   38;5;40
-*.tar                  38;5;40
-*.tbz                  38;5;40
-*.tgz                  38;5;40
-*.warc                 38;5;40
-*.WARC                 38;5;40
-*.xz                   38;5;40
-*.z                    38;5;40
-*.zip                  38;5;40
-*.zipx                 38;5;40
-*.zoo                  38;5;40
-*.zpaq                 38;5;40
-*.zst                  38;5;40
-*.zstd                 38;5;40
-*.zz                   38;5;40
-# packaged apps
-.apk                  38;5;215
-.ipa                  38;5;215
-.deb                  38;5;215
-.rpm                  38;5;215
-.jad                  38;5;215
-.jar                  38;5;215
-.ear                  38;5;215
-.war                  38;5;215
-.cab                  38;5;215
-.pak                  38;5;215
-.pk3                  38;5;215
-.vdf                  38;5;215
-.vpk                  38;5;215
-.bsp                  38;5;215
-.dmg                  38;5;215
-.crx                  38;5;215 # Google Chrome extension
-.xpi                  38;5;215 # Mozilla Firefox extension
-# segments from 0 to three digits after first extension letter
-.r[0-9]{0,2}          38;5;239
-.zx[0-9]{0,2}         38;5;239
-.z[0-9]{0,2}          38;5;239
-# partial files
-.part                 38;5;239
-# partition images
-.iso                  38;5;124
-.img                  38;5;124
-.bin                  38;5;124
-.nrg                  38;5;124
-.qcow                 38;5;124
-.fvd                  38;5;124
-.sparseimage          38;5;124
-.toast                38;5;124
-.vcd                  38;5;124
-.vdi                  38;5;124
-.vhd                  38;5;124
-.vhdx                 38;5;124
-.vfd                  38;5;124
-.vmdk                 38;5;124
-# databases
-.accdb                38;5;60
-.accde                38;5;60
-.accdr                38;5;60
-.accdt                38;5;60
-.db                   38;5;60
-.fmp12                38;5;60
-.fp7                  38;5;60
-.localstorage         38;5;60
-.mdb                  38;5;60
-.mde                  38;5;60
-.sqlite               38;5;60
-.typelib              38;5;60
-# NetCDF database
-.nc                   38;5;60
-# tempfiles
-# undo files
-.pacnew               38;5;33
-.un~                  38;5;241
-.orig                 38;5;241
-# backups
-.BUP                  38;5;241
-.bak                  38;5;241
-.o                    38;5;241 #   *nix Object file (shared libraries, core dumps etc)
-*core                 38;5;241 #   Linux user core dump file (from /proc/sys/kernel/core_pattern)
-.mdump                38;5;241 #   Mini DuMP crash report
-.rlib                 38;5;241 #   Static rust library
-.dll                  38;5;241 #   dynamic linked library
-# temporary files
-.swp                  38;5;244
-.swo                  38;5;244
-.tmp                  38;5;244
-.sassc                38;5;244
-# state files
-.pid                  38;5;248
-.state                38;5;248
-*lockfile             38;5;248
-*lock                 38;5;248
-# error logs
-.err                  38;5;160;1
-.error                38;5;160;1
-.stderr               38;5;160;1
-# state dumps
-.aria2                38;5;241
-.dump                 38;5;241
-.stackdump            38;5;241
-.zcompdump            38;5;241
-.zwc                  38;5;241
-# tcpdump, network traffic capture
-.pcap                 38;5;29
-.cap                  38;5;29
-.dmp                  38;5;29
-# macOS
-.DS_Store             38;5;239
-.localized            38;5;239
-.CFUserTextEncoding   38;5;239
-# hosts
-# /etc/hosts.{deny,allow}
-.allow                38;5;112
-.deny                 38;5;196
-# systemd
-# http://www.freedesktop.org/software/systemd/man/systemd.unit.html
-.service              38;5;45
-*@.service            38;5;45
-.socket               38;5;45
-.swap                 38;5;45
-.device               38;5;45
-.mount                38;5;45
-.automount            38;5;45
-.target               38;5;45
-.path                 38;5;45
-.timer                38;5;45
-.snapshot             38;5;45
-# metadata
-.application          38;5;116
-.cue                  38;5;116
-.description          38;5;116
-.directory            38;5;116
-.m3u                  38;5;116
-.m3u8                 38;5;116
-.md5                  38;5;116
-.properties           38;5;116
-.sfv                  38;5;116
-.theme                38;5;116
-.torrent              38;5;116
-.urlview              38;5;116
-.webloc               38;5;116
-.lnk                  38;5;39
-# macOS files
-*CodeResources        38;5;239 # code signing apps
-*PkgInfo              38;5;239 # app bundle id
-.nib                  38;5;57  # UI
-.car                  38;5;57  # asset catalog
-.dylib                38;5;241 # shared lib
-# Xcode files
-.entitlements         1
-.pbxproj              1
-.strings              1
-.storyboard           38;5;196
-.xcconfig             1
-.xcsettings           1
-.xcuserstate          1
-.xcworkspacedata      1
+
+BLK                   38;5;68             # core
+CAPABILITY            38;5;17             # core
+CHR                   38;5;113;1          # core
+DIR                   38;5;30             # core
+DOOR                  38;5;127            # core
+EXEC                  38;5;208;1          # core
+FIFO                  38;5;126            # core
+FILE                  0                   # core
+LINK                  target              # core
+MULTIHARDLINK         38;5;222;1          # core
+NORMAL                0                   # core
+ORPHAN                48;5;196;38;5;232;1 # core
+OTHER_WRITABLE        38;5;220;1          # core
+SETGID                48;5;3;38;5;0       # core
+SETUID                38;5;220;1;3;100;1  # core
+SOCK                  38;5;197            # core
+STICKY                38;5;86;48;5;234    # core
+STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3 # core
+*LS_COLORS 48;5;89;38;5;197;1;3;4;7       # :-)
+.txt                  38;5;253            # Plain-text
+*README               38;5;220;1          # Documentation
+*README.rst           38;5;220;1          # Documentation
+*README.md            38;5;220;1          # Documentation
+*LICENSE              38;5;220;1          # Documentation
+*COPYING              38;5;220;1          # Documentation
+*INSTALL              38;5;220;1          # Documentation
+*COPYRIGHT            38;5;220;1          # Documentation
+*AUTHORS              38;5;220;1          # Documentation
+*HISTORY              38;5;220;1          # Documentation
+*CONTRIBUTORS         38;5;220;1          # Documentation
+*PATENTS              38;5;220;1          # Documentation
+*VERSION              38;5;220;1          # Documentation
+*NOTICE               38;5;220;1          # Documentation
+*CHANGES              38;5;220;1          # Documentation
+.log                  38;5;190            # Logs
+.adoc                 38;5;184            # Markup
+.asciidoc             38;5;184            # Markup
+.etx                  38;5;184            # Markup
+.info                 38;5;184            # Markup
+.markdown             38;5;184            # Markup
+.md                   38;5;184            # Markup
+.mkd                  38;5;184            # Markup
+.nfo                  38;5;184            # Markup
+.org                  38;5;184            # Markup
+.pod                  38;5;184            # Markup
+.rst                  38;5;184            # Markup
+.tex                  38;5;184            # Markup
+.textile              38;5;184            # Markup
+.bib                  38;5;178            # Data store # non-relational
+.json                 38;5;178            # Data store # non-relational
+.jsonl                38;5;178            # Data store # non-relational
+.jsonnet              38;5;178            # Data store # non-relational
+.libsonnet            38;5;142            # Data store # non-relational
+.ndjson               38;5;178            # Data store # non-relational
+.msg                  38;5;178            # Data store # non-relational
+.pgn                  38;5;178            # Data store # non-relational
+.rss                  38;5;178            # Data store # non-relational
+.xml                  38;5;178            # Data store # non-relational
+.fxml                 38;5;178            # Data store # non-relational
+.toml                 38;5;178            # Data store # non-relational
+.yaml                 38;5;178            # Data store # non-relational
+.yml                  38;5;178            # Data store # non-relational
+.RData                38;5;178            # Data store # non-relational
+.rdata                38;5;178            # Data store # non-relational
+.xsd                  38;5;178            # Data store # non-relational
+.dtd                  38;5;178            # Data store # non-relational
+.sgml                 38;5;178            # Data store # non-relational
+.rng                  38;5;178            # Data store # non-relational
+.rnc                  38;5;178            # Data store # non-relational
+.accdb                38;5;60             # Data store # MS Access
+.accde                38;5;60             # Data store # MS Access
+.accdr                38;5;60             # Data store # MS Access
+.accdt                38;5;60             # Data store # MS Access
+.db                   38;5;60             # Data store
+.fmp12                38;5;60             # Data store
+.fp7                  38;5;60             # Data store
+.localstorage         38;5;60             # Data store
+.mdb                  38;5;60             # Data store
+.mde                  38;5;60             # Data store
+.sqlite               38;5;60             # Data store # SQLite
+.typelib              38;5;60             # Data store
+.nc                   38;5;60             # Data store # NetCDF
+.cbr                  38;5;141            # Documents # binary
+.cbz                  38;5;141            # Documents # binary
+.chm                  38;5;141            # Documents # binary
+.djvu                 38;5;141            # Documents # binary
+.pdf                  38;5;141            # Documents # binary
+.PDF                  38;5;141            # Documents # binary
+.mobi                 38;5;141            # Documents # binary
+.epub                 38;5;141            # Documents # binary
+.docm                 38;5;111;4          # Documents # with macros
+.doc                  38;5;111            # Documents
+.docx                 38;5;111            # Documents
+.odb                  38;5;111            # Documents
+.odt                  38;5;111            # Documents
+.rtf                  38;5;111            # Documents
+.pages                38;5;111            # Documents
+.odp                  38;5;166            # Presentation
+.pps                  38;5;166            # Presentation
+.ppt                  38;5;166            # Presentation
+.pptx                 38;5;166            # Presentation
+.ppts                 38;5;166            # Presentation
+.pptxm                38;5;166;4          # Presentation (with macros)
+.pptsm                38;5;166;4          # Presentation (with macros)
+.csv                  38;5;78             # Spreadsheet (plain text)
+.tsv                  38;5;78             # Spreadsheet (plain text)
+.numbers              38;5;112            # Spreadsheet
+.ods                  38;5;112            # Spreadsheet
+.xla                  38;5;76             # Spreadsheet
+.xls                  38;5;112            # Spreadsheet
+.xlsx                 38;5;112            # Spreadsheet
+.xlsxm                38;5;112;4          # Spreadsheet (with macros)
+.xltm                 38;5;73;4           # Spreadsheet (with macros)
+.xltx                 38;5;73             # Spreadsheet (with macros)
+.key                  38;5;166            # License keys
+*config               1                   # Configs
+*cfg                  1                   # Configs
+*conf                 1                   # Configs
+*rc                   1                   # Configs
+*authorized_keys      1                   # Configs
+*known_hosts          1                   # Configs
+.ini                  1                   # Configs
+.plist                1                   # Configs
+.profile              1                   # Configs
+.bash_profile         1                   # Configs
+.bash_login           1                   # Configs
+.bash_logout          1                   # Configs
+.zshenv               1                   # Configs
+.zprofile             1                   # Configs
+.zlogin               1                   # Configs
+.zlogout              1                   # Configs
+.viminfo              1                   # Configs
+.pcf                  1                   # Configs
+.psf                  1                   # Configs
+.hidden-color-scheme  1                   # Configs
+.hidden-tmTheme       1                   # Configs
+.last-run             1                   # Configs
+.merged-ca-bundle     1                   # Configs
+.sublime-build        1                   # Configs
+.sublime-commands     1                   # Configs
+.sublime-keymap       1                   # Configs
+.sublime-settings     1                   # Configs
+.sublime-snippet      1                   # Configs
+.sublime-project      1                   # Configs
+.sublime-workspace    1                   # Configs
+.tmTheme              1                   # Configs
+.user-ca-bundle       1                   # Configs
+.rstheme              1                   # Configs
+.epf                  1                   # Configs
+.git                  38;5;197            # Version control
+.gitignore            38;5;240            # Version control
+.gitattributes        38;5;240            # Version control
+.gitmodules           38;5;240            # Version control
+.awk                  38;5;172            # Code (shell)
+.bash                 38;5;172            # Code (shell)
+.bat                  38;5;172            # Code (shell)
+.BAT                  38;5;172            # Code (shell)
+.sed                  38;5;172            # Code (shell)
+.sh                   38;5;172            # Code (shell)
+.zsh                  38;5;172            # Code (shell)
+.vim                  38;5;172            # Code (shell)
+.kak                  38;5;172            # Code (shell)
+.ahk                  38;5;41             # Code (interpreted) (AutoHotKey)
+.py                   38;5;41             # Code (interpreted) (Python)
+.ipynb                38;5;41             # Code (interpreted) (Python)
+.xsh                  38;5;41             # Code (interpreted) (xonsh)
+.rb                   38;5;41             # Code (interpreted) (ruby)
+.gemspec              38;5;41             # Code (interpreted) (ruby)
+.pl                   38;5;208            # Code (interpreted) (Perl)
+.PL                   38;5;160            # Code (interpreted) (Perl)
+.t                    38;5;114            # Code (interpreted) (Perl)
+.msql                 38;5;222            # Code (SQL)
+.mysql                38;5;222            # Code (SQL)
+.pgsql                38;5;222            # Code (SQL)
+.sql                  38;5;222            # Code (SQL)
+.tcl                  38;5;64;1           # Code (interpreted) (Tool Command Language)
+.r                    38;5;49             # Code (interpreted) (R)
+.R                    38;5;49             # Code (interpreted) (R)
+.gs                   38;5;81             # GrADS
+.clj                  38;5;41             # Clojure
+.cljs                 38;5;41             # Clojure
+.cljc                 38;5;41             # Clojure
+.cljw                 38;5;41             # Clojure Gorilla notebook
+.scala                38;5;41             # Scala
+.sc                   38;5;41             # Scala
+.dart                 38;5;51             # Dart
+.asm                  38;5;81             # ASM
+.cl                   38;5;81             # LISP
+.lisp                 38;5;81             # LISP
+.rkt                  38;5;81             # LISP
+.el                   38;5;81             # LISP (Emacs)
+.elc                  38;5;241            # LISP (Emacs)
+.eln                  38;5;241            # LISP (Emacs)
+.lua                  38;5;81             # Code (interpreted) (Lua)
+.moon                 38;5;81             # Code (interpreted) (Moonscript)
+.c                    38;5;81             # C
+.C                    38;5;81             # C
+.h                    38;5;110            # C headers
+.H                    38;5;110            # C headers
+.tcc                  38;5;110            # C headers
+.c++                  38;5;81             # C++
+.h++                  38;5;110            # C++ headers
+.hpp                  38;5;110            # C++ headers
+.hxx                  38;5;110            # C++ headers
+.ii                   38;5;110            # C++ headers
+.M                    38;5;110            # Objective C method file
+.m                    38;5;110            # Objective C method file
+.cc                   38;5;81             # Csharp
+.cs                   38;5;81             # Csharp
+.cp                   38;5;81             # Csharp
+.cpp                  38;5;81             # Csharp
+.cxx                  38;5;81             # Csharp
+.cr                   38;5;81             # Crystal
+.go                   38;5;81             # Golang
+.f                    38;5;81             # Fortran
+.F                    38;5;81             # Fortran
+.for                  38;5;81             # Fortran
+.ftn                  38;5;81             # Fortran
+.f90                  38;5;81             # Fortran
+.F90                  38;5;81             # Fortran
+.f95                  38;5;81             # Fortran
+.F95                  38;5;81             # Fortran
+.f03                  38;5;81             # Fortran
+.F03                  38;5;81             # Fortran
+.f08                  38;5;81             # Fortran
+.F08                  38;5;81             # Fortran
+.nim                  38;5;81             # Nim
+.nimble               38;5;81             # Nim
+.s                    38;5;110            # Pascal
+.S                    38;5;110            # Pascal
+.rs                   38;5;81             # Code (compiled) (Rust)
+.scpt                 38;5;219            # AppleScript
+.swift                38;5;219            # Swift
+.sx                   38;5;81             # SimplexNumerica
+.vala                 38;5;81             # Vala
+.vapi                 38;5;81             # Vala
+.hi                   38;5;110            # Haskell
+.hs                   38;5;81             # Haskell
+.lhs                  38;5;81             # Haskell
+.agda                 38;5;81             # Agda
+.lagda                38;5;81             # Agda
+.lagda.tex            38;5;81             # Agda
+.lagda.rst            38;5;81             # Agda
+.lagda.md             38;5;81             # Agda
+.agdai                38;5;110            # Agda
+.zig                  38;5;81             # Zig
+.v                    38;5;81             # V
+.pyc                  38;5;240            # Code (Python)
+.tf                   38;5;168            # Code (Terraform)
+.tfstate              38;5;168            # Code (Terraform)
+.tfvars               38;5;168            # Code (Terraform)
+.css                  38;5;125;1          # XML
+.less                 38;5;125;1          # XML
+.sass                 38;5;125;1          # XML
+.scss                 38;5;125;1          # XML
+.htm                  38;5;125;1          # XML
+.html                 38;5;125;1          # XML
+.jhtm                 38;5;125;1          # XML
+.mht                  38;5;125;1          # XML
+.eml                  38;5;125;1          # XML
+.mustache             38;5;125;1          # XML
+.coffee               38;5;074;1          # Java
+.java                 38;5;074;1          # Java
+.js                   38;5;074;1          # Java
+.mjs                  38;5;074;1          # Java
+.jsm                  38;5;074;1          # Java
+.jsp                  38;5;074;1          # Java
+.php                  38;5;81             # php
+.ctp                  38;5;81             # php (CakePHP)
+.twig                 38;5;81             # php (Twig)
+.vb                   38;5;81             # VBA
+.vba                  38;5;81             # VBA
+.vbs                  38;5;81             # VBA
+*Dockerfile           38;5;155            # Build process (Docker)
+.dockerignore         38;5;240            # Build process (Docker)
+*Makefile             38;5;155            # Build process (Make)
+*MANIFEST             38;5;243            # Build process (Make)
+*pm_to_blib           38;5;240            # Build process (Perl)
+.nix                  38;5;155            # Functional configuration
+.dhall                38;5;178            # Functional configuration
+.rake                 38;5;155            # Build process (Ruby)
+.am                   38;5;242            # Build process (Automake)
+.in                   38;5;242            # Build process (Automake)
+.hin                  38;5;242            # Build process (Automake)
+.scan                 38;5;242            # Build process (Automake)
+.m4                   38;5;242            # Build process (Automake)
+.old                  38;5;242            # Build process (Automake)
+.out                  38;5;242            # Build process (Automake)
+.SKIP                 38;5;244            # Build process (Automake)
+.diff                 48;5;197;38;5;232   # Patch files
+.patch                48;5;197;38;5;232;1 # Patch files
+.bmp                  38;5;97             # Graphics
+.dicom                38;5;97             # Graphics
+.tiff                 38;5;97             # Graphics
+.tif                  38;5;97             # Graphics
+.TIFF                 38;5;97             # Graphics
+.cdr                  38;5;97             # Graphics
+.flif                 38;5;97             # Graphics
+.gif                  38;5;97             # Graphics
+.icns                 38;5;97             # Graphics
+.ico                  38;5;97             # Graphics
+.jpeg                 38;5;97             # Graphics
+.JPG                  38;5;97             # Graphics
+.jpg                  38;5;97             # Graphics
+.nth                  38;5;97             # Graphics
+.png                  38;5;97             # Graphics
+.psd                  38;5;97             # Graphics
+.pxd                  38;5;97             # Graphics
+.pxm                  38;5;97             # Graphics
+.xpm                  38;5;97             # Graphics
+.webp                 38;5;97             # Graphics
+.ai                   38;5;99             # Graphics (Vector)
+.eps                  38;5;99             # Graphics (Vector)
+.epsf                 38;5;99             # Graphics (Vector)
+.drw                  38;5;99             # Graphics (Vector)
+.ps                   38;5;99             # Graphics (Vector)
+.svg                  38;5;99             # Graphics (Vector)
+.avi                  38;5;114            # Video
+.divx                 38;5;114            # Video
+.IFO                  38;5;114            # Video
+.m2v                  38;5;114            # Video
+.m4v                  38;5;114            # Video
+.mkv                  38;5;114            # Video
+.MOV                  38;5;114            # Video
+.mov                  38;5;114            # Video
+.mp4                  38;5;114            # Video
+.mpeg                 38;5;114            # Video
+.mpg                  38;5;114            # Video
+.ogm                  38;5;114            # Video
+.rmvb                 38;5;114            # Video
+.sample               38;5;114            # Video
+.wmv                  38;5;114            # Video
+.3g2                  38;5;115            # Video (mobile/streaming)
+.3gp                  38;5;115            # Video (mobile/streaming)
+.gp3                  38;5;115            # Video (mobile/streaming)
+.webm                 38;5;115            # Video (mobile/streaming)
+.gp4                  38;5;115            # Video (mobile/streaming)
+.asf                  38;5;115            # Video (mobile/streaming)
+.flv                  38;5;115            # Video (mobile/streaming)
+.ts                   38;5;115            # Video (mobile/streaming)
+.ogv                  38;5;115            # Video (mobile/streaming)
+.f4v                  38;5;115            # Video (mobile/streaming)
+.VOB                  38;5;115;1          # Video (lossless)
+.vob                  38;5;115;1          # Video (lossless)
+.ass                  38;5;117            # Subtitles
+.srt                  38;5;117            # Subtitles
+.ssa                  38;5;117            # Subtitles
+.sub                  38;5;117            # Subtitles
+.sup                  38;5;117            # Subtitles
+.vtt                  38;5;117            # Subtitles
+.3ga                  38;5;137;1          # Audio (lossy)
+.S3M                  38;5;137;1          # Audio (lossy)
+.aac                  38;5;137;1          # Audio (lossy)
+.amr                  38;5;137;1          # Audio (lossy)
+.au                   38;5;137;1          # Audio (lossy)
+.caf                  38;5;137;1          # Audio (lossy)
+.dat                  38;5;137;1          # Audio (lossy)
+.dts                  38;5;137;1          # Audio (lossy)
+.fcm                  38;5;137;1          # Audio (lossy)
+.m4a                  38;5;137;1          # Audio (lossy)
+.mod                  38;5;137;1          # Audio (lossy)
+.mp3                  38;5;137;1          # Audio (lossy)
+.mp4a                 38;5;137;1          # Audio (lossy)
+.oga                  38;5;137;1          # Audio (lossy)
+.ogg                  38;5;137;1          # Audio (lossy)
+.opus                 38;5;137;1          # Audio (lossy)
+.s3m                  38;5;137;1          # Audio (lossy)
+.sid                  38;5;137;1          # Audio (lossy)
+.wma                  38;5;137;1          # Audio (lossy)
+.ape                  38;5;136;1          # Audio (lossless)
+.aiff                 38;5;136;1          # Audio (lossless)
+.cda                  38;5;136;1          # Audio (lossless)
+.flac                 38;5;136;1          # Audio (lossless)
+.alac                 38;5;136;1          # Audio (lossless)
+.mid                  38;5;136;1          # Audio (lossless)
+.midi                 38;5;136;1          # Audio (lossless)
+.pcm                  38;5;136;1          # Audio (lossless)
+.wav                  38;5;136;1          # Audio (lossless)
+.wv                   38;5;136;1          # Audio (lossless)
+.wvc                  38;5;136;1          # Audio (lossless)
+.afm                  38;5;66             # Fonts
+.fon                  38;5;66             # Fonts
+.fnt                  38;5;66             # Fonts
+.pfb                  38;5;66             # Fonts
+.pfm                  38;5;66             # Fonts
+.ttf                  38;5;66             # Fonts
+.otf                  38;5;66             # Fonts
+.woff                 38;5;66             # Fonts
+.woff2                38;5;66             # Fonts
+.PFA                  38;5;66             # Fonts
+.pfa                  38;5;66             # Fonts
+*.7z                  38;5;40             # Archives
+*.a                   38;5;40             # Archives
+*.arj                 38;5;40             # Archives
+*.bz2                 38;5;40             # Archives
+*.cpio                38;5;40             # Archives
+*.gz                  38;5;40             # Archives
+*.lrz                 38;5;40             # Archives
+*.lz                  38;5;40             # Archives
+*.lzma                38;5;40             # Archives
+*.lzo                 38;5;40             # Archives
+*.rar                 38;5;40             # Archives
+*.s7z                 38;5;40             # Archives
+*.sz                  38;5;40             # Archives
+*.tar                 38;5;40             # Archives
+*.tbz                 38;5;40             # Archives
+*.tgz                 38;5;40             # Archives
+*.warc                38;5;40             # Archives
+*.WARC                38;5;40             # Archives
+*.xz                  38;5;40             # Archives
+*.z                   38;5;40             # Archives
+*.zip                 38;5;40             # Archives
+*.zipx                38;5;40             # Archives
+*.zoo                 38;5;40             # Archives
+*.zpaq                38;5;40             # Archives
+*.zst                 38;5;40             # Archives
+*.zstd                38;5;40             # Archives
+*.zz                  38;5;40             # Archives
+.apk                  38;5;215            # Packaged apps
+.ipa                  38;5;215            # Packaged apps
+.deb                  38;5;215            # Packaged apps
+.rpm                  38;5;215            # Packaged apps
+.jad                  38;5;215            # Packaged apps
+.jar                  38;5;215            # Packaged apps
+.ear                  38;5;215            # Packaged apps
+.war                  38;5;215            # Packaged apps
+.cab                  38;5;215            # Packaged apps
+.pak                  38;5;215            # Packaged apps
+.pk3                  38;5;215            # Packaged apps
+.vdf                  38;5;215            # Packaged apps
+.vpk                  38;5;215            # Packaged apps
+.bsp                  38;5;215            # Packaged apps
+.dmg                  38;5;215            # Packaged apps
+.crx                  38;5;215            # Packaged apps # Google Chrome extension
+.xpi                  38;5;215            # Packaged apps # Mozilla Firefox extension
+.iso                  38;5;124            # Partition images
+.img                  38;5;124            # Partition images
+.bin                  38;5;124            # Partition images
+.nrg                  38;5;124            # Partition images
+.qcow                 38;5;124            # Partition images
+.fvd                  38;5;124            # Partition images
+.sparseimage          38;5;124            # Partition images
+.toast                38;5;124            # Partition images
+.vcd                  38;5;124            # Partition images
+.vdi                  38;5;124            # Partition images
+.vhd                  38;5;124            # Partition images
+.vhdx                 38;5;124            # Partition images
+.vfd                  38;5;124            # Partition images
+.vmdk                 38;5;124            # Partition images
+.swp                  38;5;244            # Temporary files
+.swo                  38;5;244            # Temporary files
+.tmp                  38;5;244            # Temporary files
+.sassc                38;5;244            # Temporary files
+.pacnew               38;5;33             # Undo files
+.un~                  38;5;241            # Undo files
+.orig                 38;5;241            # Undo files
+.BUP                  38;5;241            # Backups
+.bak                  38;5;241            # Backups
+.o                    38;5;241            # *nix Object file (shared libraries, core dumps etc)
+*core                 38;5;241            # Linux user core dump file (from /proc/sys/kernel/core_pattern)
+.mdump                38;5;241            # Mini DuMP crash report
+.rlib                 38;5;241            # Static rust library
+.dll                  38;5;241            # dynamic linked library
+.aria2                38;5;241            # state dumps
+.dump                 38;5;241            # state dumps
+.stackdump            38;5;241            # state dumps
+.zcompdump            38;5;241            # state dumps
+.zwc                  38;5;241            # state dumps
+.part                 38;5;239            # Partial files
+.r[0-9]{0,2}          38;5;239            # Archive segments
+.zx[0-9]{0,2}         38;5;239            # Archive segments
+.z[0-9]{0,2}          38;5;239            # Archive segments
+.pid                  38;5;248            # state files
+.state                38;5;248            # state files
+*lockfile             38;5;248            # state files
+*lock                 38;5;248            # state files
+.err                  38;5;160;1          # error logs
+.error                38;5;160;1          # error logs
+.stderr               38;5;160;1          # error logs
+.pcap                 38;5;29             # tcpdump / network traffic capture
+.cap                  38;5;29             # tcpdump / network traffic capture
+.dmp                  38;5;29             # tcpdump / network traffic capture
+.allow                38;5;112            # /etc/hosts
+.deny                 38;5;196            # /etc/hosts
+.service              38;5;45             # systemd
+*@.service            38;5;45             # systemd
+.socket               38;5;45             # systemd
+.swap                 38;5;45             # systemd
+.device               38;5;45             # systemd
+.mount                38;5;45             # systemd
+.automount            38;5;45             # systemd
+.target               38;5;45             # systemd
+.path                 38;5;45             # systemd
+.timer                38;5;45             # systemd
+.snapshot             38;5;45             # systemd
+.lnk                  38;5;39             # windows symlink
+.application          38;5;116            # metadata
+.cue                  38;5;116            # metadata
+.description          38;5;116            # metadata
+.directory            38;5;116            # metadata
+.m3u                  38;5;116            # metadata
+.m3u8                 38;5;116            # metadata
+.md5                  38;5;116            # metadata
+.properties           38;5;116            # metadata
+.sfv                  38;5;116            # metadata
+.theme                38;5;116            # metadata
+.torrent              38;5;116            # metadata
+.urlview              38;5;116            # metadata
+.webloc               38;5;116            # metadata
+.asc                  38;5;192;3          # Encrypted data
+.bfe                  38;5;192;3          # Encrypted data
+.enc                  38;5;192;3          # Encrypted data
+.gpg                  38;5;192;3          # Encrypted data
+.signature            38;5;192;3          # Encrypted data
+.sig                  38;5;192;3          # Encrypted data
+.p12                  38;5;192;3          # Encrypted data
+.pem                  38;5;192;3          # Encrypted data
+.pgp                  38;5;192;3          # Encrypted data
+.p7s                  38;5;192;3          # Encrypted data
+*id_dsa               38;5;192;3          # Encrypted data
+*id_rsa               38;5;192;3          # Encrypted data
+*id_ecdsa             38;5;192;3          # Encrypted data
+*id_ed25519           38;5;192;3          # Encrypted data
+.32x                  38;5;213            # Game console emulation
+.cdi                  38;5;213            # Game console emulation
+.fm2                  38;5;213            # Game console emulation
+.rom                  38;5;213            # Game console emulation
+.sav                  38;5;213            # Game console emulation
+.st                   38;5;213            # Game console emulation
+.a00                  38;5;213            # Game console emulation # Atari
+.a52                  38;5;213            # Game console emulation # Atari
+.A64                  38;5;213            # Game console emulation # Atari
+.a64                  38;5;213            # Game console emulation # Atari
+.a78                  38;5;213            # Game console emulation # Atari
+.adf                  38;5;213            # Game console emulation # Atari
+.atr                  38;5;213            # Game console emulation # Atari
+.gb                   38;5;213            # Game console emulation # Nintendo
+.gba                  38;5;213            # Game console emulation # Nintendo
+.gbc                  38;5;213            # Game console emulation # Nintendo
+.gel                  38;5;213            # Game console emulation # Nintendo
+.gg                   38;5;213            # Game console emulation # Nintendo
+.ggl                  38;5;213            # Game console emulation # Nintendo
+.ipk                  38;5;213            # Game console emulation # Nintendo DS Packed Images
+.j64                  38;5;213            # Game console emulation # Nintendo
+.nds                  38;5;213            # Game console emulation # Nintendo
+.nes                  38;5;213            # Game console emulation # Nintendo NES
+.sms                  38;5;213            # Sega
+.8xp                  38;5;121            # Texas Instruments Calculator files
+.8eu                  38;5;121            # Texas Instruments Calculator files
+.82p                  38;5;121            # Texas Instruments Calculator files
+.83p                  38;5;121            # Texas Instruments Calculator files
+.8xe                  38;5;121            # Texas Instruments Calculator files
+.stl                  38;5;216            # 3D printing
+.dwg                  38;5;216            # 3D printing
+.ply                  38;5;216            # 3D printing
+.wrl                  38;5;216            # 3D printing
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# unknown / weirdos
 .xib                  38;5;208
-# encrypted data
-.asc                  38;5;192;3
-.bfe                  38;5;192;3
-.enc                  38;5;192;3
-.gpg                  38;5;192;3
-.signature            38;5;192;3
-.sig                  38;5;192;3
-.p12                  38;5;192;3
-.pem                  38;5;192;3
-.pgp                  38;5;192;3
-.p7s                  38;5;192;3
-*id_dsa                38;5;192;3
-*id_rsa                38;5;192;3
-*id_ecdsa              38;5;192;3
-*id_ed25519            38;5;192;3
-# emulators
-.32x                  38;5;213
-.cdi                  38;5;213
-.fm2                  38;5;213
-.rom                  38;5;213
-.sav                  38;5;213
-.st                   38;5;213
-  # atari
-.a00                  38;5;213
-.a52                  38;5;213
-.A64                  38;5;213
-.a64                  38;5;213
-.a78                  38;5;213
-.adf                  38;5;213
-.atr                  38;5;213
-  # nintendo
-.gb                   38;5;213
-.gba                  38;5;213
-.gbc                  38;5;213
-.gel                  38;5;213
-.gg                   38;5;213
-.ggl                  38;5;213
-.ipk                  38;5;213 # Nintendo (DS Packed Images)
-.j64                  38;5;213
-.nds                  38;5;213
-.nes                  38;5;213
-  # Sega
-.sms                  38;5;213
-# Texas Instruments Calculator files
-# for more see http://tibasicdev.wikidot.com/file-extensions
-.8xp                  38;5;121
-.8eu                  38;5;121
-.82p                  38;5;121
-.83p                  38;5;121
-.8xe                  38;5;121
-# 3D printing
-.stl                  38;5;216
-.dwg                  38;5;216
-.ply                  38;5;216
-.wrl                  38;5;216
+.iml                  38;5;166            # AppCode files
+
+.DS_Store             38;5;239            # macOS
+.localized            38;5;239            # macOS
+.CFUserTextEncoding   38;5;239            # macOS
+*CodeResources        38;5;239            # macOS code signing apps
+*PkgInfo              38;5;239            # macOS app bundle id
+.nib                  38;5;57             # macOS UI
+.car                  38;5;57             # macOS asset catalog
+.dylib                38;5;241            # macOS shared lib
+.entitlements         1                   # Xcode files
+.pbxproj              1                   # Xcode files
+.strings              1                   # Xcode files
+.storyboard           38;5;196            # Xcode files
+.xcconfig             1                   # Xcode files
+.xcsettings           1                   # Xcode files
+.xcuserstate          1                   # Xcode files
+.xcworkspacedata      1                   # Xcode files
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # unsorted
-# Portable Object Translation for GNU Gettext
 .pot                  38;5;7
-# CAD files for printed circuit boards
 .pcb                  38;5;7
-# groff (rendering app for texinfo)
 .mm                   38;5;7
-# GIMP files
 .gbr                  38;5;7
 .scm                  38;5;7
 .xcf                  38;5;7
-# printer spool file
 .spl                  38;5;7
-# RStudio project file
 .Rproj                38;5;11
-# Nokia Symbian OS files
 .sis                  38;5;7
 .1p                   38;5;7
 .3p                   38;5;7
@@ -772,11 +652,11 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .tfm                  38;5;7
 .tfnt                 38;5;7
 .tg                   38;5;7
-.vcard                38;5;7
-.vcf                  38;5;7 #contact information
+.vcard                38;5;7 # contact information
+.vcf                  38;5;7 # contact information
 .xln                  38;5;7
-# AppCode files
-.iml                  38;5;166
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # termcap
 TERM ansi
 TERM color-xterm
@@ -829,5 +709,3 @@ TERM xterm-88color
 TERM xterm-color
 TERM xterm-debian
 TERM xterm-kitty
-
-# vim: ft=dircolors:fdm=marker:et:sw=2:

--- a/LS_COLORS
+++ b/LS_COLORS
@@ -30,7 +30,7 @@
 # You should have received a copy of the Perl Artistic License along
 # with this program.  If not, see <http://www.perlfoundation.org/artistic_license_1_0>.
 
-# core {{{1
+# core
 BLK                   38;5;68
 CAPABILITY            38;5;17
 CHR                   38;5;113;1
@@ -53,8 +53,7 @@ SOCK                  38;5;197
 STICKY                38;5;86;48;5;234
 STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 *LS_COLORS 48;5;89;38;5;197;1;3;4;7 # :-)
-# }}}
-# documents {{{1
+# documents
 *README               38;5;220;1
 *README.rst           38;5;220;1
 *README.md            38;5;220;1
@@ -70,11 +69,9 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 *NOTICE               38;5;220;1
 *CHANGES              38;5;220;1
 .log                  38;5;190
-# }}}
-# plain-text {{{2
+# plain-text
 .txt                  38;5;253
-# }}}
-# markup {{{2
+# markup
 .adoc                 38;5;184
 .asciidoc             38;5;184
 .etx                  38;5;184
@@ -88,8 +85,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .rst                  38;5;184
 .tex                  38;5;184
 .textile              38;5;184
-# }}}
-# key-value, non-relational data {{{2
+# key-value, non-relational data
 .bib                  38;5;178
 .json                 38;5;178
 .jsonl                38;5;178
@@ -111,8 +107,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .sgml                 38;5;178
 .rng                  38;5;178
 .rnc                  38;5;178
-# }}}
-# binary {{{2
+# binary
 .cbr                  38;5;141
 .cbz                  38;5;141
 .chm                  38;5;141
@@ -121,8 +116,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .PDF                  38;5;141
 .mobi                 38;5;141
 .epub                 38;5;141
-# }}}
-# Microsoft {{{2
+# Microsoft
 # words
 .docm                 38;5;111;4
 .doc                  38;5;111
@@ -159,8 +153,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .pages                38;5;111
 .numbers              38;5;112
 .key                  38;5;166
-# }}}
-# configs {{{2
+# configs
 *config               1
 *cfg                  1
 *conf                 1
@@ -203,8 +196,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .rstheme              1
 # eclipse
 .epf                  1
-# }}}
-# code {{{1
+# code
 # version control
 .git                  38;5;197
 .gitignore            38;5;240
@@ -256,8 +248,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .sc                   38;5;41
 # Dart
 .dart                 38;5;51
-# }}}
-# compiled {{{2
+# compiled
 # assembly language
 .asm                  38;5;81
 # LISP
@@ -345,13 +336,11 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .v                    38;5;81
 # Python
 .pyc                  38;5;240
-# }}}
-# orchestration {{{2
+# orchestration
 .tf                   38;5;168
 .tfstate              38;5;168
 .tfvars               38;5;168
-# }}}
-# html {{{2
+# html
 .css                  38;5;125;1
 .less                 38;5;125;1
 .sass                 38;5;125;1
@@ -362,28 +351,24 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .mht                  38;5;125;1
 .eml                  38;5;125;1
 .mustache             38;5;125;1
-# }}}
-# java {{{2
+# java
 .coffee               38;5;074;1
 .java                 38;5;074;1
 .js                   38;5;074;1
 .mjs                  38;5;074;1
 .jsm                  38;5;074;1
 .jsp                  38;5;074;1
-# }}}
-# php {{{2
+# php
 .php                  38;5;81
 # CakePHP view scripts and helpers
 .ctp                  38;5;81
 # Twig template engine
 .twig                 38;5;81
-# }}}
-# vb/a {{{2
+# vb/a
 .vb                   38;5;81
 .vba                  38;5;81
 .vbs                  38;5;81
-# 2}}}
-# Build stuff {{{2
+# Build stuff
 *Dockerfile           38;5;155
 .dockerignore         38;5;240
 *Makefile             38;5;155
@@ -403,12 +388,10 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .old                  38;5;242
 .out                  38;5;242
 .SKIP                 38;5;244
-# }}}
-# patch files {{{2
+# patch files
 .diff                 48;5;197;38;5;232
 .patch                48;5;197;38;5;232;1
-# }}}
-# graphics {{{1
+# graphics
 .bmp                  38;5;97
 .dicom                38;5;97
 .tiff                 38;5;97
@@ -429,16 +412,14 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .pxm                  38;5;97
 .xpm                  38;5;97
 .webp                 38;5;97
-# }}}
-# vector {{{1
+# vector
 .ai                   38;5;99
 .eps                  38;5;99
 .epsf                 38;5;99
 .drw                  38;5;99
 .ps                   38;5;99
 .svg                  38;5;99
-# }}}
-# video {{{1
+# video
 .avi                  38;5;114
 .divx                 38;5;114
 .IFO                  38;5;114
@@ -454,7 +435,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .rmvb                 38;5;114
 .sample               38;5;114
 .wmv                  38;5;114
-# mobile/streaming {{{2
+# mobile/streaming
 .3g2                  38;5;115
 .3gp                  38;5;115
 .gp3                  38;5;115
@@ -465,20 +446,17 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .ts                   38;5;115
 .ogv                  38;5;115
 .f4v                  38;5;115
-# }}}
-# lossless {{{2
+# lossless
 .VOB                  38;5;115;1
 .vob                  38;5;115;1
-# }}}
-# subtitles {{{1
+# subtitles
 .ass                  38;5;117
 .srt                  38;5;117
 .ssa                  38;5;117
 .sub                  38;5;117
 .sup                  38;5;117 # bitmap image track
 .vtt                  38;5;117
-# }}}
-# audio {{{1
+# audio
 .3ga                  38;5;137;1
 .S3M                  38;5;137;1
 .aac                  38;5;137;1
@@ -510,8 +488,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .wav                  38;5;136;1
 .wv                   38;5;136;1
 .wvc                  38;5;136;1
-# }}}
-# fonts {{{1
+# fonts
 .afm                  38;5;66
 .fon                  38;5;66
 .fnt                  38;5;66
@@ -525,8 +502,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 # postscript fonts
 .PFA                  38;5;66
 .pfa                  38;5;66
-# }}}
-# archives {{{1
+# archives
 *.7z                   38;5;40
 *.a                    38;5;40
 *.arj                  38;5;40
@@ -554,8 +530,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 *.zst                  38;5;40
 *.zstd                 38;5;40
 *.zz                   38;5;40
-# }}}
-# packaged apps {{{2
+# packaged apps
 .apk                  38;5;215
 .ipa                  38;5;215
 .deb                  38;5;215
@@ -573,15 +548,13 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .dmg                  38;5;215
 .crx                  38;5;215 # Google Chrome extension
 .xpi                  38;5;215 # Mozilla Firefox extension
-# }}}
-# segments from 0 to three digits after first extension letter {{{2
+# segments from 0 to three digits after first extension letter
 .r[0-9]{0,2}          38;5;239
 .zx[0-9]{0,2}         38;5;239
 .z[0-9]{0,2}          38;5;239
 # partial files
 .part                 38;5;239
-# }}}
-# partition images {{{2
+# partition images
 .iso                  38;5;124
 .img                  38;5;124
 .bin                  38;5;124
@@ -596,8 +569,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .vhdx                 38;5;124
 .vfd                  38;5;124
 .vmdk                 38;5;124
-# }}}
-# databases {{{2
+# databases
 .accdb                38;5;60
 .accde                38;5;60
 .accdr                38;5;60
@@ -612,8 +584,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .typelib              38;5;60
 # NetCDF database
 .nc                   38;5;60
-# }}}
-# tempfiles {{{1
+# tempfiles
 # undo files
 .pacnew               38;5;33
 .un~                  38;5;241
@@ -654,13 +625,11 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .DS_Store             38;5;239
 .localized            38;5;239
 .CFUserTextEncoding   38;5;239
-# }}}
-# hosts {{{1
+# hosts
 # /etc/hosts.{deny,allow}
 .allow                38;5;112
 .deny                 38;5;196
-# }}}
-# systemd {{{1
+# systemd
 # http://www.freedesktop.org/software/systemd/man/systemd.unit.html
 .service              38;5;45
 *@.service            38;5;45
@@ -673,8 +642,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .path                 38;5;45
 .timer                38;5;45
 .snapshot             38;5;45
-# }}}
-# metadata {{{1
+# metadata
 .application          38;5;116
 .cue                  38;5;116
 .description          38;5;116
@@ -689,15 +657,13 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .urlview              38;5;116
 .webloc               38;5;116
 .lnk                  38;5;39
-# }}}
-# macOS files {{{1
+# macOS files
 *CodeResources        38;5;239 # code signing apps
 *PkgInfo              38;5;239 # app bundle id
 .nib                  38;5;57  # UI
 .car                  38;5;57  # asset catalog
 .dylib                38;5;241 # shared lib
-# }}}
-# Xcode files {{{2
+# Xcode files
 .entitlements         1
 .pbxproj              1
 .strings              1
@@ -707,8 +673,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .xcuserstate          1
 .xcworkspacedata      1
 .xib                  38;5;208
-# }}}
-# encrypted data {{{1
+# encrypted data
 .asc                  38;5;192;3
 .bfe                  38;5;192;3
 .enc                  38;5;192;3
@@ -723,8 +688,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 *id_rsa                38;5;192;3
 *id_ecdsa              38;5;192;3
 *id_ed25519            38;5;192;3
-# }}}
-# emulators {{{1
+# emulators
 .32x                  38;5;213
 .cdi                  38;5;213
 .fm2                  38;5;213
@@ -752,22 +716,19 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .nes                  38;5;213
   # Sega
 .sms                  38;5;213
-# }}}
-# Texas Instruments Calculator files {{{1
+# Texas Instruments Calculator files
 # for more see http://tibasicdev.wikidot.com/file-extensions
 .8xp                  38;5;121
 .8eu                  38;5;121
 .82p                  38;5;121
 .83p                  38;5;121
 .8xe                  38;5;121
-# }}}
-# 3D printing {{{1
+# 3D printing
 .stl                  38;5;216
 .dwg                  38;5;216
 .ply                  38;5;216
 .wrl                  38;5;216
-# }}}
-# unsorted {{{1
+# unsorted
 # Portable Object Translation for GNU Gettext
 .pot                  38;5;7
 # CAD files for printed circuit boards
@@ -816,8 +777,7 @@ STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3
 .xln                  38;5;7
 # AppCode files
 .iml                  38;5;166
-# }}}
-# termcap {{{1
+# termcap
 TERM ansi
 TERM color-xterm
 TERM con132x25
@@ -869,5 +829,5 @@ TERM xterm-88color
 TERM xterm-color
 TERM xterm-debian
 TERM xterm-kitty
-# }}}
+
 # vim: ft=dircolors:fdm=marker:et:sw=2:


### PR DESCRIPTION
This change restructures the LS_COLORS file without making any changes to dircolors output, as I confirmed via the Makefile.

- vim-specific folds and annotations are removed.
- Sorting of the extensions is reworked a bit, although this still isn't as scientific as I would like. It's progress though.
- Comments are moved inline and many new comments are added. These comments are formatted to prepare for parsing the LS_COLORS file out into style sheets to help enforce stylistic consistency.