### PR TITLE
fix: Makefile syntax and whitespace quoting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FILE_NAME=lscolors
-export XDG_DATA_HOME ?= $${$$HOME/.local/share}
-
+XDG_DATA_HOME ?= $(HOME)/.local/share
+XDG_DATA_HOME := "$(XDG_DATA_HOME)"
 all: generate
 
 clean:
@@ -12,11 +12,11 @@ generate: clean
 	@command sort LS_COLORS | dircolors --c-shell      - > ${FILE_NAME}.csh
 
 install: generate
-	@command cp ${FILE_NAME}.sh ${FILE_NAME}.csh ${XDG_DATA_HOME}
+	@command cp ${FILE_NAME}.sh ${FILE_NAME}.csh $(XDG_DATA_HOME)
 	@echo "To enable the colors, add the following line to your shell's start-up script:"
 	@echo ""
 	@echo "For Bourne shell (e.g. ~/.bashrc or ~/.zshrc):"
-	@echo "   source ${XDG_DATA_HOME}/${FILE_NAME}.sh"
+	@echo "   source $(XDG_DATA_HOME)/${FILE_NAME}.sh"
 	@echo ""
 	@echo "For C shell (e.g. ~/.cshrc):"
-	@echo "   source ${XDG_DATA_HOME}/${FILE_NAME}.csh"
+	@echo "   source $(XDG_DATA_HOME)/${FILE_NAME}.csh"


### PR DESCRIPTION
As mentioned in the linked issue, the previous syntax caused a syntax error if `XDG_DATA_HOME` was undefined.

```console
$ unset XDG_DATA_HOME
$ make install
/bin/sh: ${$HOME/.local/share}: bad substitution
make: *** [install] Error 1
```

This does away with the `$$` escaping, and leans into Make's standard `$()` substitution syntax. The logic goes like this:
- If `XDG_DATA_HOME` is not defined, assign it to `$HOME/.local/share` (now, value of `$HOME` is evaluated right away instead of being deferred; effectively changes nothing)
- Quote `$(XDG_DATA_HOME)`, in case parts of it contain whitespace (Make does not evaluate the quotation marks, Bash will once `$(XDG_DATA_HOME)` is substituted)

This also removes the `export` - it's not necessary


Closes #201