### PR TITLE
style(editorconfig): Add rule for Makefile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ charset = utf-8
 
 [*.sh]
 indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
This adds an entry for the `Makefile` in the EditorConfig file. Without this, my editor automatically uses spaces for indentation.