### PR TITLE
fix: Reset `LC_ALL` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+export LC_ALL=C
 FILE_NAME=lscolors
 export XDG_DATA_HOME ?= $${$$HOME/.local/share}
 


### PR DESCRIPTION
This improves the reproducability of the Makefile by setting `LC_ALL`. For examples, `sort` will give more consistent output, regardless of the user environment's default language.

Closes #194