### PR TITLE
Add notes about RHEL image for WSL

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -84,11 +84,14 @@ integration with bash, csh, or zsh.
 ### RHEL image for WSL
 [RHEL image for WSL](https://developers.redhat.com/articles/2023/11/15/create-customized-rhel-images-wsl-environment#) is very basic compared to [Ubuntu WSL](https://ubuntu.com/desktop/wsl), lacking additional beautification features.
 
-To have a colorized terminal output, you need to add the following line to the ~/.bashrc
+To have a colorized terminal output, you need to add the following line to the **~/.bashrc**
+
+```
+vim ~/.bashrc
+```
 
 ```
 # Source terminal color schemas
-vim ~/.bashrc
 source ~/LS_COLORS/lscolors.sh
 export LS_OPTIONS='--color=auto'
 alias ls='ls $LS_OPTIONS'

--- a/README.markdown
+++ b/README.markdown
@@ -81,6 +81,20 @@ $
 Arch Linux users can install the [`lscolors-git`][3] package from the AUR for easy
 integration with bash, csh, or zsh.
 
+### RHEL images for WSL
+[RHEL images for WSL](https://developers.redhat.com/articles/2023/11/15/create-customized-rhel-images-wsl-environment#) is very basic compared to [Ubuntu WSL](https://ubuntu.com/desktop/wsl), lacking additional beautification features.
+
+To have a colorized terminal output, you need to add the following line to the ~/.bashrc
+
+```
+# Source terminal color schemas
+vim ~/.bashrc
+source ~/LS_COLORS/lscolors.sh
+export LS_OPTIONS='--color=auto'
+alias ls='ls $LS_OPTIONS'
+```
+
+
 ## Information for Developers
 
 There's a [library][1] I've written that lets you use various LS COLORS on

--- a/README.markdown
+++ b/README.markdown
@@ -81,8 +81,8 @@ $
 Arch Linux users can install the [`lscolors-git`][3] package from the AUR for easy
 integration with bash, csh, or zsh.
 
-### RHEL images for WSL
-[RHEL images for WSL](https://developers.redhat.com/articles/2023/11/15/create-customized-rhel-images-wsl-environment#) is very basic compared to [Ubuntu WSL](https://ubuntu.com/desktop/wsl), lacking additional beautification features.
+### RHEL image for WSL
+[RHEL image for WSL](https://developers.redhat.com/articles/2023/11/15/create-customized-rhel-images-wsl-environment#) is very basic compared to [Ubuntu WSL](https://ubuntu.com/desktop/wsl), lacking additional beautification features.
 
 To have a colorized terminal output, you need to add the following line to the ~/.bashrc
 


### PR DESCRIPTION
RHEL image for WSL is very basic compared to Ubuntu WSL, lacking additional beautification features.
To have a colorized terminal output, you need to add the following line to the ~/.bashrc